### PR TITLE
Fix to prevent BACnet scan crashes from individual device failures

### DIFF
--- a/Dockerfile.ubuntu2204
+++ b/Dockerfile.ubuntu2204
@@ -1,0 +1,26 @@
+FROM ubuntu:22.04
+
+WORKDIR /tmp
+RUN apt update && apt -y install build-essential zlib1g-dev libncurses5-dev libgdbm-dev libnss3-dev libssl-dev libreadline-dev libffi-dev libsqlite3-dev wget 
+RUN wget https://www.openssl.org/source/openssl-1.1.1g.tar.gz 
+RUN wget https://www.python.org/ftp/python/3.12.8/Python-3.12.8.tgz
+RUN tar -xzvf Python-3.12.8.tgz
+
+RUN apt -y remove openssl
+RUN tar -zxf openssl-1.1.1g.tar.gz
+RUN tar -xzvf Python-3.12.8.tgz
+
+WORKDIR /tmp/openssl-1.1.1g
+RUN ./config
+RUN make
+RUN make install
+RUN cp -r libssl.so.1.1 /usr/lib && cp -r libcrypto.so.1.1 /usr/lib
+
+WORKDIR /tmp/Python-3.12.8
+RUN ./configure --enable-optimizations --with-openssl=/usr/local --with-ensurepip=install CFLAGS="-I/usr/include" LDFLAGS="-Wl,-rpath /usr/local/lib" --enable-shared --prefix=/usr/local
+RUN make
+RUN make install
+
+RUN python3 -m pip install pyinstaller
+
+WORKDIR /root

--- a/bacnet-scan.py
+++ b/bacnet-scan.py
@@ -184,77 +184,47 @@ def enumerate_device_points(bacnet, discovered_devices):
 
 def create_data(output_path, verbose, discovered_devices, network, devicesonly):
     devices = {}
-    devices_info = {}
     points = {}
+    
     for each in discovered_devices:
         name, vendor, address, device_id = each
-
-        custom_obj_list = None
-        
         sanitized_dev_name = sanitize_device_name(name)
 
-        devices[sanitized_dev_name] = BAC0.device(
-            address, device_id, network, poll=0, object_list=custom_obj_list
-        )
-
-        # devices_info[sanitized_dev_name] = make_device_info(output_path, verbose, each, network)
-
-        if not devicesonly:
-            points[sanitized_dev_name] = make_points(output_path, verbose, devices[sanitized_dev_name], sanitized_dev_name)
-    # return (devices, devices_info, points)
-    return (devices,points)
+        try:
+            devices[sanitized_dev_name] = BAC0.device(
+                address, device_id, network, poll=0, object_list=None
+            )
+            
+            if not devicesonly:
+                points[sanitized_dev_name] = make_points(output_path, verbose, devices[sanitized_dev_name], sanitized_dev_name)
+        
+        except Exception as e:
+            print(f"Failed to initialize/enumerate device {name} ({address}): {e}")
+            continue
+            
+    return (devices, points)
 
 def make_device_info_simple(output_path, verbose, dev, network):
-    lst = {}
+    data = {
+        "device_name": "N/A", "device_vendor": "N/A", "device_model": "N/A",
+        "device_firmware": "N/A", "description": "N/A", "location": "N/A",
+        "device_application_version": "N/A", "device_serial_number": "N/A",
+        "ip_address": dev[2], "device_id": dev[3]
+    }
     
     try:
-        address, device_id = dev
-    except:
-        name, manufacturer, address, device_id = dev
-
-    # device = BAC0.device(
-    #         address, device_id, network, poll=0
-    #     )
-    
-    # try:
-    #     ipaddress.ip_address(address)
-    # except ValueError:
-    #     pass
-    
-    try:
-        object_name, vendor_name, firmware_version, model_name, serial_number, description, location, application_software_version = (
-            network.readMultiple(
-                f"{address} device {device_id} objectName vendorName"
-                " firmwareRevision modelName serialNumber description location applicationSoftwareVersion"
-            )
+        props = network.readMultiple(
+            f"{dev[2]} device {dev[3]} objectName vendorName "
+            "firmwareRevision modelName serialNumber description location applicationSoftwareVersion"
         )
+        data.update({
+            "device_name": props.get('objectName', 'N/A'),
+            "device_vendor": props.get('vendorName', 'N/A'),
+        })
+    except Exception as e:
+        print(f"Skipping detailed read for {dev[2]} due to: {e}")
 
-        # logging.info("object_name: %s vendor_name: %s firmware: %s model: %s serial: %s description: %s location: %s",  
-        #               object_name, vendor_name, firmware_version, model_name, serial_number, description, location, application_software_version)
-        # print(f"object_name: {object_name} vendor_name: %s firmware: %s model: %s serial: %s description: %s location: %s",  
-        #                vendor_name, firmware_version, model_name, serial_number, description, location, application_software_version)
-
-    except (BAC0.core.io.IOExceptions.SegmentationNotSupported, Exception) as err:
-        # logging.exception(f"error reading from {address}/{device_id}")
-        print(f"error reading from {address}/{device_id}")
-    
-    sanitized_dev_name = sanitize_device_name(object_name)
-    
-    lst = {
-            "device_name": object_name,
-            "sanitized_device_name": sanitized_dev_name,
-            "device_vendor": vendor_name,
-            "device_model": model_name,
-            "device_firmware": firmware_version,
-            "description": description,
-            "location": location,
-            "device_application_version": application_software_version,
-            "device_serial_number": serial_number,
-            "ip_address": address,
-            "device_id": device_id
-            # "network": network_number
-        }
-    df = pd.DataFrame.from_dict(lst, orient="index")
+    df = pd.DataFrame.from_dict(data, orient="index")
     df.index.name = "property"
     df.rename(columns={0: "value"}, inplace=True)
     
@@ -599,11 +569,13 @@ def main():
     bacnet_devices_df.to_csv(os.path.join(output_path, "%s_devicelist_simple.csv" % SHEET_FILENAME_NAME))
 
     for device in discovered_devices:
-        # print(dir(device))
-        address = device[0]
-        device_id = device[1]
-        # print(address, device_id)
-        devices_df = pd.concat( [devices_df, make_device_info_simple(output_path, args.verbose, device, network=bacnet)], ignore_index=True, axis=1)
+        try:
+            device_data = make_device_info_simple(output_path, args.verbose, device, network=bacnet)
+            if not device_data.empty:
+                devices_df = pd.concat([devices_df, device_data], ignore_index=True, axis=1)
+        except Exception as e:
+            print(f"Critical error processing device {device[3]}: {e}")
+            continue
         
     # pprint(devices_df)
 

--- a/build-podman.sh
+++ b/build-podman.sh
@@ -1,25 +1,28 @@
 #!/bin/sh
 
-#./pyinstaller-osbuilder-debian11-podman.sh
-#./pyinstaller-osbuilder-debian12-podman.sh
-#./pyinstaller-osbuilder-debian13-podman.sh
-#./pyinstaller-osbuilder-rocky810-podman.sh
-#./pyinstaller-osbuilder-ubuntu1604-podman.sh
-#./pyinstaller-osbuilder-ubuntu1804-podman.sh
-#./pyinstaller-osbuilder-ubuntu2004-podman.sh
+./pyinstaller-osbuilder-debian11-podman.sh
+./pyinstaller-osbuilder-debian12-podman.sh
+./pyinstaller-osbuilder-debian13-podman.sh
+./pyinstaller-osbuilder-rocky810-podman.sh
+./pyinstaller-osbuilder-ubuntu1604-podman.sh
+./pyinstaller-osbuilder-ubuntu1804-podman.sh
+./pyinstaller-osbuilder-ubuntu2004-podman.sh
+./pyinstaller-osbuilder-ubuntu2204-podman.sh
 
-#./pyinstaller-appbuilder-bacnet-scan-debian11-podman.sh
-#./pyinstaller-appbuilder-bacnet-scan-debian12-podman.sh
-#./pyinstaller-appbuilder-bacnet-scan-debian13-podman.sh
+./pyinstaller-appbuilder-bacnet-scan-debian11-podman.sh
+./pyinstaller-appbuilder-bacnet-scan-debian12-podman.sh
+./pyinstaller-appbuilder-bacnet-scan-debian13-podman.sh
 ./pyinstaller-appbuilder-bacnet-scan-rocky810-podman.sh
 ./pyinstaller-appbuilder-bacnet-scan-ubuntu1604-podman.sh
 ./pyinstaller-appbuilder-bacnet-scan-ubuntu1804-podman.sh
 ./pyinstaller-appbuilder-bacnet-scan-ubuntu2004-podman.sh
+./pyinstaller-appbuilder-bacnet-scan-ubuntu2204-podman.sh
 
-#./pyinstaller-appbuilder-sheet2mangojson-debian11-podman.sh
-#./pyinstaller-appbuilder-sheet2mangojson-debian12-podman.sh
-#./pyinstaller-appbuilder-sheet2mangojson-debian13-podman.sh
+./pyinstaller-appbuilder-sheet2mangojson-debian11-podman.sh
+./pyinstaller-appbuilder-sheet2mangojson-debian12-podman.sh
+./pyinstaller-appbuilder-sheet2mangojson-debian13-podman.sh
 ./pyinstaller-appbuilder-sheet2mangojson-rocky810-podman.sh
 ./pyinstaller-appbuilder-sheet2mangojson-ubuntu1604-podman.sh
 ./pyinstaller-appbuilder-sheet2mangojson-ubuntu1804-podman.sh
 ./pyinstaller-appbuilder-sheet2mangojson-ubuntu2004-podman.sh
+./pyinstaller-appbuilder-sheet2mangojson-ubuntu2204-podman.sh

--- a/pyinstaller-appbuilder-bacnet-scan-ubuntu2204-podman.sh
+++ b/pyinstaller-appbuilder-bacnet-scan-ubuntu2204-podman.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+set -x
+ROOT_DIR=$(realpath $(dirname $0)/)
+
+TMP_DIR=$(mktemp -d)
+OUT_DIR=$ROOT_DIR/dist
+OUT_FILE=$OUT_DIR/bacnet-scan-ubuntu2204
+
+echo Building binary to 
+cat >$TMP_DIR/build.sh <<-EOF
+            set -x
+            rm -rf /tmp/bacnet-scan
+            rm -rf /dist/bacnet-scan
+            mkdir /build
+            cp -r /src/bacnet-scan.py /build
+            cp -r /src/bacnet-scan.spec /build
+            cp -r /src/requirements.txt /build
+            cd /build
+            python3 -m pip install --upgrade pip
+            python3 -m pip install -r requirements.txt
+            wget https://github.com/pisuke/BAC0/archive/refs/heads/unknown-units-2023.zip
+            unzip unknown-units-2023.zip
+            python3 -m pip install ./BAC0-unknown-units-2023/
+            ls -la /usr/local/lib/python3.12/site-packages
+            ls -la /usr/local/lib/python3.12/site-packages/packaging
+            ls -la /usr/local/lib/python3.12/site-packages/pkg_resources
+            ls -la /usr/local/lib/python3.12/lib-dynload
+            python3 --version
+            python3 -m pandas
+            pyinstaller --onefile --hidden-import=pandas bacnet-scan.py
+            ls -la dist/*
+            mv dist/bacnet-scan /tmp/bacnet-scan
+EOF
+
+podman run --rm --network host --volume $ROOT_DIR/:/src --volume $TMP_DIR:/tmp pyinstaller-builder-ubuntu-2204:latest /bin/bash /tmp/build.sh
+mkdir -p $OUT_DIR
+mv $TMP_DIR/bacnet-scan $OUT_FILE
+chmod 777 $OUT_FILE

--- a/pyinstaller-appbuilder-sheet2mangojson-ubuntu2204-podman.sh
+++ b/pyinstaller-appbuilder-sheet2mangojson-ubuntu2204-podman.sh
@@ -1,0 +1,28 @@
+#!/bin/bash -e
+set -x
+ROOT_DIR=$(realpath $(dirname $0)/)
+
+TMP_DIR=$(mktemp -d)
+OUT_DIR=$ROOT_DIR/dist
+OUT_FILE=$OUT_DIR/sheet2mangojson-ubuntu2204
+
+echo Building binary to 
+cat >$TMP_DIR/build.sh <<-EOF
+            set -x
+            rm -rf /tmp/sheet2mangojson
+            rm -rf /dist/sheet2mangojson
+            mkdir /build
+            cp -r /src/sheet2mangojson.py /build
+            cp -r /src/requirements.txt /build
+            cd /build
+            python3 -m pip install --upgrade pip
+            python3 -m pip install -r requirements.txt
+            pyinstaller --onefile --hidden-import=pandas sheet2mangojson.py
+            ls -la dist/*
+            mv dist/sheet2mangojson /tmp/sheet2mangojson
+EOF
+
+podman run --rm --volume $ROOT_DIR/:/src --volume $TMP_DIR:/tmp pyinstaller-builder-ubuntu-2204:latest /bin/bash /tmp/build.sh
+mkdir -p $OUT_DIR
+mv $TMP_DIR/sheet2mangojson $OUT_FILE
+chmod 777 $OUT_FILE

--- a/pyinstaller-osbuilder-ubuntu2204-podman.sh
+++ b/pyinstaller-osbuilder-ubuntu2204-podman.sh
@@ -1,0 +1,3 @@
+#!/bin/bash -e
+
+podman build --network host -f Dockerfile.ubuntu2204 -t pyinstaller-builder-ubuntu-2204 .


### PR DESCRIPTION
The BACnet scanning script was terminating the entire discovery process if a single device failed to respond to a read request or if it contained unsupported properties (e.g., throwing an UnknownPropertyError for objects lacking a standard property).

Main changes:
* make_device_info_simple: Initialised device properties with default "N/A" values and isolated the readMultiple network call within a try-except block. This allows the script to return partial data (like just the IP and Device ID) instead of terminating.
* main loop (discovered_devices): Wrapped the device processing and DataFrame concatenation in a try-except-continue block so the loop proceeds to the next device upon encountering an error.
* create_data: Encapsulated the BAC0.device instantiation inside a try-except-continue block to catch automatic point enumeration failures and gracefully skip the problematic device.